### PR TITLE
Issue #19: Install error: info file does not define a 'type' attribute

### DIFF
--- a/tests/geofield_openlayers_test.info
+++ b/tests/geofield_openlayers_test.info
@@ -3,6 +3,7 @@ description = "Integration tests for Geofield and Openlayers"
 core = 7.x
 hidden = TRUE
 package = Testing
+type = module
 
 dependencies[] = geofield
 dependencies[] = openlayers


### PR DESCRIPTION
https://github.com/backdrop-contrib/geofield/issues/19